### PR TITLE
move whitelist_constantize require to lib and not ctrlr

### DIFF
--- a/app/controllers/comply/validations_controller.rb
+++ b/app/controllers/comply/validations_controller.rb
@@ -1,4 +1,3 @@
-require 'comply/whitelist_constantize'
 begin
   require 'strong_parameters'
 rescue LoadError

--- a/lib/comply.rb
+++ b/lib/comply.rb
@@ -1,5 +1,6 @@
 require 'comply/engine'
 require 'ssl_requirement'
+require 'comply/whitelist_constantize'
 
 module Comply
 end

--- a/lib/comply/version.rb
+++ b/lib/comply/version.rb
@@ -1,3 +1,3 @@
 module Comply
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end


### PR DESCRIPTION
Otherwise when you change any code in the lumos_rails controllers, rails will automagically reload controllers but not the `whitelist_constantize` module because it doesn't see it. This requires `whitelist_constantize` in the main gem loading place so it stays when automagical reload happens.