### PR TITLE
Change require to activemodel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+# 1.5.1
+* Add fix for rails 4 where activemodel/validations directory does not work
+
 # 1.5.0
 * Rails 4.0.13 compatibility

--- a/lib/comply/version.rb
+++ b/lib/comply/version.rb
@@ -1,3 +1,3 @@
 module Comply
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end

--- a/lib/comply/whitelist_constantize.rb
+++ b/lib/comply/whitelist_constantize.rb
@@ -1,4 +1,4 @@
-require 'active_model/validations'
+require 'active_model'
 
 module Comply
   module WhitelistConstantize


### PR DESCRIPTION
@zvkemp 

Need this change since local bundle is giving the following error on rails 4:
```
➜  sentinel git:(sentinel-4.0.13) ✗ bundle exec rspec
/Users/amatuszewski/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/activemodel-4.0.13/lib/active_model/validations/absence.rb:4:in `<module:Validations>': uninitialized constant ActiveModel::Validations::EachValidator (NameError)
        from /Users/amatuszewski/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/activemodel-4.0.13/lib/active_model/validations/absence.rb:2:in `<module:ActiveModel>'
        from /Users/amatuszewski/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/activemodel-4.0.13/lib/active_model/validations/absence.rb:1:in `<top (required)>'
        from /Users/amatuszewski/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/activemodel-4.0.13/lib/active_model/validations.rb:379:in `require'
        from /Users/amatuszewski/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/activemodel-4.0.13/lib/active_model/validations.rb:379:in `block in <top (required)>'
        from /Users/amatuszewski/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/activemodel-4.0.13/lib/active_model/validations.rb:379:in `each'
        from /Users/amatuszewski/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/activemodel-4.0.13/lib/active_model/validations.rb:379:in `<top (required)>'
        from /Users/amatuszewski/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/comply-1.5.0/lib/comply/whitelist_constantize.rb:1:in `require'
        from /Users/amatuszewski/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/comply-1.5.0/lib/comply/whitelist_constantize.rb:1:in `<top (required)>'
        from /Users/amatuszewski/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/comply-1.5.0/lib/comply.rb:3:in `require'
        from /Users/amatuszewski/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/comply-1.5.0/lib/comply.rb:3:in `<top (required)>'
        from /Users/amatuszewski/workspace/lumos_rails/engines/sentinel/lib/sentinel.rb:2:in `require'
        from /Users/amatuszewski/workspace/lumos_rails/engines/sentinel/lib/sentinel.rb:2:in `<top (required)>'
```

I think this is due to nesting change for the files.