### PR TITLE
Set :comply context on validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.7.0
+* Pass custom context `:comply` to validations (the former context used to default to `:create`)
+
 # 1.6.0
 * Move Rails 4 & 3 compatibility to Gemfile rather than gemspec
 

--- a/app/controllers/comply/validations_controller.rb
+++ b/app/controllers/comply/validations_controller.rb
@@ -13,7 +13,7 @@ module Comply
 
     def show
       @instance = validation_instance
-      @instance.valid?
+      @instance.valid?(:comply)
       render json: { error: @instance.errors }
     end
 

--- a/lib/comply/version.rb
+++ b/lib/comply/version.rb
@@ -1,3 +1,3 @@
 module Comply
-  VERSION = '1.6.0'
+  VERSION = '1.7.0'
 end

--- a/spec/controllers/comply/validations_controller_spec.rb
+++ b/spec/controllers/comply/validations_controller_spec.rb
@@ -52,6 +52,27 @@ describe Comply::ValidationsController, type: :controller do
       end
     end
 
+    context 'with comply-skipped validations' do
+      let(:fields) do
+        {
+          title: 'title',
+          description: nil,
+          rating: 5,
+          release_date: Date.today
+        }
+      end
+
+      it 'does not error' do
+        expect(response).to be_success
+      end
+
+      specify 'even though the model is invalid' do
+        movie = Movie.new(fields)
+        expect(movie).to be_invalid
+        expect(movie.valid?(:comply)).to eq(true)
+      end
+    end
+
     context 'without a model given' do
       let(:model) { '' }
 

--- a/spec/dummy/app/models/movie.rb
+++ b/spec/dummy/app/models/movie.rb
@@ -1,6 +1,6 @@
 class Movie < ActiveRecord::Base
   validates_presence_of :title
-  validates_presence_of :description
+  validates_presence_of :description, unless: -> { validation_context == :comply }
   validates_presence_of :release_date
   validates :rating, inclusion: 1..5
   validate :released_less_than_a_year_ago


### PR DESCRIPTION
This will allow to do things such as `validate :that_thing, on: :comply`.
It should have no repercussion on existent code (unless of course someone was using `on: :comply` already), because the context used to be nil.

cc @cfurrow @11mdlow 
