### PR TITLE
Stop sending validations as get requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.9.0
+* Support both POST and GET at the `/validations` endpoint
+* Deprecate support for GET at the `/validations` endpoint
+
 # 1.7.0
 * Pass custom context `:comply` to validations (the former context used to default to `:create`)
 

--- a/app/assets/javascripts/comply/base_validatable_form.js.coffee
+++ b/app/assets/javascripts/comply/base_validatable_form.js.coffee
@@ -14,7 +14,7 @@ class Comply.BaseValidatableForm
     @validate inputs: @inputs, submit: true
 
   validate: (options) ->
-    $.get @validationRoute, @_params(), (response) =>
+    $.post @validationRoute, @_params(), (response) =>
       @_onValidate(response, options)
 
       if @_allSuccess(response)

--- a/app/controllers/comply/validations_controller.rb
+++ b/app/controllers/comply/validations_controller.rb
@@ -12,6 +12,7 @@ module Comply
     end
 
     def show
+      ActiveSupport::Deprecation.warn('GET support going away: use POST to access this endpoint') if request.request_method == 'GET'
       @instance = validation_instance
       @instance.valid?(validation_context)
       render json: { error: @instance.errors }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Comply::Engine.routes.draw do
-  match '/validations' => 'validations#show', via: [:post]
+  match '/validations' => 'validations#show', via: [:get, :post]
   # allow CORS requests
   match 'validations', via: [:options], to: proc { [200, {}, ['']] }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Comply::Engine.routes.draw do
-  match '/validations' => 'validations#show', via: [:get]
+  match '/validations' => 'validations#show', via: [:post]
   # allow CORS requests
   match 'validations', via: [:options], to: proc { [200, {}, ['']] }
 end

--- a/lib/comply/version.rb
+++ b/lib/comply/version.rb
@@ -1,3 +1,3 @@
 module Comply
-  VERSION = '1.8.1.beta2'
+  VERSION = '1.8.1'
 end

--- a/lib/comply/version.rb
+++ b/lib/comply/version.rb
@@ -1,3 +1,3 @@
 module Comply
-  VERSION = '1.8.0'
+  VERSION = '1.8.1.beta'
 end

--- a/lib/comply/version.rb
+++ b/lib/comply/version.rb
@@ -1,3 +1,3 @@
 module Comply
-  VERSION = '1.8.1.beta'
+  VERSION = '1.8.1.beta2'
 end

--- a/lib/comply/version.rb
+++ b/lib/comply/version.rb
@@ -1,3 +1,3 @@
 module Comply
-  VERSION = '1.8.1'
+  VERSION = '1.9.0'
 end

--- a/spec/controllers/comply/validations_controller_spec.rb
+++ b/spec/controllers/comply/validations_controller_spec.rb
@@ -22,107 +22,133 @@ describe Comply::ValidationsController, type: :controller do
       }
     end
 
-    subject { get :show, params }
+    shared_examples_for :comply_validations_controller do
+      context 'when model is valid' do
+        it 'returns success' do
+          subject
+          expect(response).to be_success
+        end
 
-    context 'when model is valid' do
-      it 'returns success' do
-        subject
-        expect(response).to be_success
+        it 'returns no errors' do
+          subject
+          expect(response_body).to eql({'error' => {}})
+        end
       end
 
-      it 'returns no errors' do
-        subject
-        expect(response_body).to eql({'error' => {}})
-      end
-    end
+      context 'with invalid fields' do
+        let(:fields) do
+          {
+            title: nil,
+            description: 'Brendan Frazier & Pauly Shore are "funny"',
+            rating: 5,
+            release_date: Date.today
+          }
+        end
 
-    context 'with invalid fields' do
-      let(:fields) do
-        {
-          title: nil,
-          description: 'Brendan Frazier & Pauly Shore are "funny"',
-          rating: 5,
-          release_date: Date.today
-        }
-      end
-
-      it 'returns an error message' do
-        subject
-        expect(response_body['error']).to include('title' => ["can't be blank"] )
-      end
-    end
-
-    context 'with comply-skipped validations' do
-      let(:fields) do
-        {
-          title: 'title',
-          description: nil,
-          rating: 5,
-          release_date: Date.today
-        }
+        it 'returns an error message' do
+          subject
+          expect(response_body['error']).to include('title' => ["can't be blank"] )
+        end
       end
 
-      it 'does not error' do
-        expect(response).to be_success
-      end
+      context 'with comply-skipped validations' do
+        let(:fields) do
+          {
+            title: 'title',
+            description: nil,
+            rating: 5,
+            release_date: Date.today
+          }
+        end
 
-      specify 'even though the model is invalid' do
-        movie = Movie.new(fields)
-        expect(movie).to be_invalid
-        expect(movie.valid?(:comply)).to eq(true)
-      end
+        it 'does not error' do
+          expect(response).to be_success
+        end
 
-      context 'in a new validation_context' do
-        class Comply::ValidationsController
-          def validation_context
-            :no_longer_comply
+        specify 'even though the model is invalid' do
+          movie = Movie.new(fields)
+          expect(movie).to be_invalid
+          expect(movie.valid?(:comply)).to eq(true)
+        end
+
+        context 'in a new validation_context' do
+          class Comply::ValidationsController
+            def validation_context
+              :no_longer_comply
+            end
+          end
+
+          it 'throws an error' do
+            subject
+            expect(response_body['error']).to include('description' => ["can't be blank"] )
           end
         end
+      end
 
-        it 'throws an error' do
+      context 'without a model given' do
+        let(:model) { '' }
+
+        it 'returns an error' do
           subject
-          expect(response_body['error']).to include('description' => ["can't be blank"] )
+          expect(response_body).to eql({'error' => 'Model not found'})
+          expect(response.status).to be(500)
+        end
+      end
+
+      context 'without fields given' do
+        let(:fields) { {} }
+
+        it 'returns an error' do
+          subject
+          expect(response_body).to eql({'error' => 'Form fields not found'})
+          expect(response.status).to be(500)
+        end
+      end
+
+      context 'when model class does not exist' do
+        let(:model) { 'thisisnotreal' }
+
+        it 'returns an error' do
+          subject
+          expect(response_body).to eql({'error' => 'Model not found'})
+          expect(response.status).to be(500)
+        end
+      end
+
+      context 'when model is not validatable' do
+        let(:model) { 'hash' }
+
+        it 'returns an error' do
+          subject
+          expect(response_body).to eql({'error' => 'Model not found'})
+          expect(response.status).to be(500)
         end
       end
     end
 
-    context 'without a model given' do
-      let(:model) { '' }
+    context 'POST request to validations endpoint' do
+      subject { post :show, params }
 
-      it 'returns an error' do
-        subject
-        expect(response_body).to eql({'error' => 'Model not found'})
-        expect(response.status).to be(500)
+      it_behaves_like :comply_validations_controller
+
+      context 'POST method is supported' do
+        it 'does not emit a deprecation notice' do
+          expect(ActiveSupport::Deprecation).not_to receive(:warn).with('GET support going away: use POST to access this endpoint')
+          subject
+        end
       end
     end
 
-    context 'without fields given' do
-      let(:fields) { {} }
+    context 'GET request to validations endpoint' do
+      subject { get :show, params }
 
-      it 'returns an error' do
-        subject
-        expect(response_body).to eql({'error' => 'Form fields not found'})
-        expect(response.status).to be(500)
-      end
-    end
+      it_behaves_like :comply_validations_controller
 
-    context 'when model class does not exist' do
-      let(:model) { 'thisisnotreal' }
-
-      it 'returns an error' do
-        subject
-        expect(response_body).to eql({'error' => 'Model not found'})
-        expect(response.status).to be(500)
-      end
-    end
-
-    context 'when model is not validatable' do
-      let(:model) { 'hash' }
-
-      it 'returns an error' do
-        subject
-        expect(response_body).to eql({'error' => 'Model not found'})
-        expect(response.status).to be(500)
+      context 'GET method is deprecated' do
+        it 'emits a deprecation notice' do
+          expect(ActiveSupport::Deprecation).to receive(:warn).with('GET support going away: use POST to access this endpoint')
+          subject
+        end
       end
     end
   end


### PR DESCRIPTION
* Supporting both GET and POST requests
* Emitting a deprecation notice for GET requests